### PR TITLE
Add game locations to gameinfo files

### DIFF
--- a/sourcemods/ep1chaos/gameinfo.txt
+++ b/sourcemods/ep1chaos/gameinfo.txt
@@ -23,6 +23,7 @@
 			game					|all_source_engine_paths|episodic
 			game					|all_source_engine_paths|hl2
 			platform				|all_source_engine_paths|platform
+			game					"..\..\common\Half-Life 2\episodic"
 		}
 	}
 	

--- a/sourcemods/ep2chaos/gameinfo.txt
+++ b/sourcemods/ep2chaos/gameinfo.txt
@@ -27,6 +27,7 @@
 			game					|all_source_engine_paths|episodic
 			game					|all_source_engine_paths|hl2
 			platform				|all_source_engine_paths|platform
+			game					"..\..\common\Half-Life 2\ep2"
 		}
 	}
 	

--- a/sourcemods/hl2chaos/gameinfo.txt
+++ b/sourcemods/hl2chaos/gameinfo.txt
@@ -20,6 +20,7 @@
 			platform				|all_source_engine_paths|platform/platform_misc.vpk
 			game					|all_source_engine_paths|hl2
 			platform				|all_source_engine_paths|platform
+			game					"..\..\common\Half-Life 2\hl2"
 		}
 	}
 	


### PR DESCRIPTION
This adds game locations to gameinfos for the mod to be able to load maps without copying them manually.

It assumes that the sourcemods folder is in the same steam directory as the base game, but it usually is for the most people. Even if the game is placed somewhere else, users can fall back to the manual map copying as it is right now.

Paths are last in the list to make sure that most of the important files are loaded from the ssdk depot and only the missing files are loaded from the game