### PR TITLE
Prevent using arrow keys to look when horizontal look is disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ ipch
 *.idb
 *.vcxproj
 *.sln
+*\.vs
 
 # OSX/Linux build products
 *.mak

--- a/sourcemods/ep1chaos/cfg/yaw.cfg
+++ b/sourcemods/ep1chaos/cfg/yaw.cfg
@@ -1,1 +1,3 @@
 m_yaw 0.022
+-right
+-left

--- a/sourcemods/ep2chaos/cfg/yaw.cfg
+++ b/sourcemods/ep2chaos/cfg/yaw.cfg
@@ -1,1 +1,3 @@
 m_yaw 0.022
+-right
+-left

--- a/sourcemods/hl2chaos/cfg/yaw.cfg
+++ b/sourcemods/hl2chaos/cfg/yaw.cfg
@@ -1,1 +1,3 @@
 m_yaw 0.022
+-right
+-left

--- a/sp/src/game/server/hl2/hl2_player.cpp
+++ b/sp/src/game/server/hl2/hl2_player.cpp
@@ -5581,7 +5581,7 @@ void CChaosEffect::StartEffect()
 		engine->ClientCommand(engine->PEntityOfEntIndex(1), "mat_picmip 4;r_lod 6;mat_filtertextures 0;mat_filterlightmaps 0");
 		break;
 	case EFFECT_NO_MOUSE_HORIZONTAL:
-		engine->ClientCommand(engine->PEntityOfEntIndex(1), "sv_cheats 1;wait 10;m_yaw 0.0f");//speculative fix for movement becoming inverted
+		engine->ClientCommand(engine->PEntityOfEntIndex(1), "sv_cheats 1;wait 10;m_yaw 0.0f;+right;+left");//speculative fix for movement becoming inverted
 		break;
 	case EFFECT_NO_MOUSE_VERTICAL:
 		engine->ClientCommand(engine->PEntityOfEntIndex(1), "sv_cheats 1;wait 10;m_pitch 0.0f");//speculative fix for movement becoming inverted


### PR DESCRIPTION
just a shrimple way to stop arrow key use

Not totally prevented since you can just -right or -left in console to stop it, but i mean you can also just change m_yaw during it too :p