### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ No build enviroment setup required.
 2. `cd halflife2chaos`
 3. `./sp/src/creategameprojects`
 4. `make -f ./sp/src/games.mak -j$(grep processor /proc/cpuinfo | wc -l) client_hl2 server_hl2`
-5. `ln -s $(pwd)/sp/game/mod_hl2/bin ./sourcemods/hl2chaos/` Link bin directory from our build directory
+5. `ln -s $(pwd)/sp/game/bin ./sourcemods/hl2chaos/` Link bin directory from our build directory
 6. `mkdir ~/.steam/steam/steamapps/sourcemods/hl2chaos; sudo mount --bind $(pwd)/sourcemods/hl2chaos ~/.steam/steam/steamapps/sourcemods/hl2chaos` Note the use of the bind mount instead of a symbolic link. Steam won't detect symbolic links. You can use `mv` or `cp` instead, if you don't care.
 
 Compiling for the episodes is an excercise for the reader. (Should be similar but with `mod_episodic`, `client_episodic` and `server_episodic`.)


### PR DESCRIPTION
current instructions don't work as-is because the bin folder is in a different location now than it was previously